### PR TITLE
Grepl Issue Fix

### DIFF
--- a/apps/app_shiny_DGE_edgeR.R
+++ b/apps/app_shiny_DGE_edgeR.R
@@ -1136,13 +1136,8 @@ server <- function(input, output, session) {
     # calculate the log CPM of the gene count data
     logcpm <- cpm(list, log=TRUE)
     # subset the log CPM by the DGE set
-    logcpmSubset <- subset(logcpm,
-                           grepl(
-                             paste0(rownames(DGESubset), collapse = "|"),
-                             rownames(logcpm),
-                             ignore.case = TRUE
-                           )
-    )
+    selected_rows <- rownames(logcpm) %in% rownames(DGESubset)
+    logcpmSubset <- logcpm[selected_rows, ]
     # create the DGE heatmap
     heatmap(logcpmSubset, main= "Heatmap of DGE")
   }


### PR DESCRIPTION
Initially I had an issue while generating the heatmap in the part of `Analysis & Results` with DGE:

![4b6e05131b8251a734517a27594e673c](https://github.com/ElizabethBrooks/DGEAnalysis_ShinyApps/assets/142265839/0f37773d-078e-4416-b7eb-d71c472fbf26)

I guess it was because that the data is really abundant and `grepl` to handle that amount of data. I made a small modification and that works. Don't know whether it makes sense to you.

<img width="580" alt="image" src="https://github.com/ElizabethBrooks/DGEAnalysis_ShinyApps/assets/142265839/8dc1ac26-093f-481d-aafa-435320398819">
